### PR TITLE
View frame size unintentionally changes after pushed on a view with different frame size

### DIFF
--- a/OldStyleNavigationControllerAnimatedTransition.m
+++ b/OldStyleNavigationControllerAnimatedTransition.m
@@ -42,17 +42,15 @@
         fromEndX = screenFrame.size.width;
     }
 
-    toViewController.view.frame = CGRectOffset(screenFrame, toStartX, 0);
+    toViewController.view.frame = CGRectOffset(toViewController.view.frame, toStartX, 0);
     [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^
     {
-        toViewController.view.frame = screenFrame;
+        toViewController.view.frame = CGRectOffset(toViewController.view.frame, -toStartX, 0);
         fromViewController.view.frame = CGRectOffset(screenFrame, fromEndX, 0);
     } completion:^(BOOL finished) {
         [fromViewController.view removeFromSuperview];
         [transitionContext completeTransition:YES];
     }];
 }
-
-
 
 @end


### PR DESCRIPTION
Hi, thanks for this useful stuff!

I just found a small issue during work with custom split views which have different frame dimensions (the original version assumes both of the prev and next view have the same dimensions).

Cheers!
